### PR TITLE
Add support for LP campaign info

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ Initialize the library by instantiating an object with the necessary options (se
 
 ```javascript
 var windowKit = new windowKit({
-	account: <your LivePerson account number here>
-	//skillId: 12341234 - optional skill ID
+	account: <your LivePerson account number here>,
+	campaignId: 12341234,
+	engagementId: 12341234,
+	//skillId: 12341234 - or optional skill ID
 });
 ```
 

--- a/message-window.js
+++ b/message-window.js
@@ -293,9 +293,7 @@ function windowKit(options) {
 
     this.socketOpened = function(socket) {
         socket.registerRequests(_this.options.apiRequestTypes);
-        var convBody = _this.options.skillId ? {
-			skillId: _this.options.skillId
-		} : {};
+        var convBody = _this.createConvBody();
         socket.initConnection({},this.initStack);
         setInterval(function() {
             socket.getClock();
@@ -448,6 +446,16 @@ function windowKit(options) {
         _this.callBackStack[key].forEach(function(callback) {
             (callback)(a[1] || null, a[2] || null, a[3] || null);
         });
+    };
+
+    this.createConvBody = function() {
+        var convBody = {};
+        if (_this.options.campaignId && _this.options.engagementId) {
+            convBody = { campaignInfo: { campaignId: _this.options.campaignId, engagementId: _this.options.engagementId }};
+        } else if(_this.options.skillId) {
+            convBody = { skillId: _this.options.skillId };
+        }
+        return convBody;
     };
 
     (function(instance) {


### PR DESCRIPTION
Add support for passing campaign info (_campaign id and engagement id_) by creating a convBody method. Updated readme to reflect this. This should be preferred for correct reporting and attribution vs just using skill id.

Minified version needs to be produced.